### PR TITLE
Explicitly say to MacOS users that package depends on libcouchbase

### DIFF
--- a/modules/ROOT/pages/start-using-sdk.adoc
+++ b/modules/ROOT/pages/start-using-sdk.adoc
@@ -58,7 +58,7 @@ sudo pecl install couchbase
 
 == Installation on Mac OS X
 
-On MacOS, the `libcouchbase` package was available in https://brew.sh[homebrew/core], and could be installed with:
+On MacOS, the `libcouchbase` package is available in https://brew.sh[homebrew/core], and could be installed with:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/start-using-sdk.adoc
+++ b/modules/ROOT/pages/start-using-sdk.adoc
@@ -58,6 +58,13 @@ sudo pecl install couchbase
 
 == Installation on Mac OS X
 
+On MacOS, `libcouchbase` package available in https://brew.sh[homebrew/core], and could be installed with:
+
+[source,bash]
+----
+brew install libcouchbase
+----
+
 As `homebrew/php` is no longer available, the current best way to install newer versions of PHP (and one with the necessary permissions) is found at https://php-osx.liip.ch[^].
 Download `install.sh` from there or, if you are happy with the script, install in one line (in this example, PHP 7.2) with:
 

--- a/modules/ROOT/pages/start-using-sdk.adoc
+++ b/modules/ROOT/pages/start-using-sdk.adoc
@@ -58,7 +58,7 @@ sudo pecl install couchbase
 
 == Installation on Mac OS X
 
-On MacOS, `libcouchbase` package available in https://brew.sh[homebrew/core], and could be installed with:
+On MacOS, the `libcouchbase` package was available in https://brew.sh[homebrew/core], and could be installed with:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/start-using-sdk.adoc
+++ b/modules/ROOT/pages/start-using-sdk.adoc
@@ -58,7 +58,7 @@ sudo pecl install couchbase
 
 == Installation on Mac OS X
 
-On MacOS, the `libcouchbase` package is available in https://brew.sh[homebrew/core], and could be installed with:
+On MacOS, the `libcouchbase` package is available in https://brew.sh[homebrew/core], and can be installed with:
 
 [source,bash]
 ----


### PR DESCRIPTION
https://forums.couchbase.com/t/error-when-installing-php-sdk-on-macos/19972