### PR TITLE
Update start-using-sdk.adoc

### DIFF
--- a/modules/ROOT/pages/start-using-sdk.adoc
+++ b/modules/ROOT/pages/start-using-sdk.adoc
@@ -33,6 +33,13 @@ sudo wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key
 echo "deb http://packages.couchbase.com/ubuntu cosmic cosmic/main" | sudo tee /etc/apt/sources.list.d/couchbase.list
 ----
 
+For Ubuntu 19.04, use _bionic_
+[source,bash]
+----
+sudo wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
+echo "deb http://packages.couchbase.com/ubuntu bionic bionic/main" | sudo tee /etc/apt/sources.list.d/couchbase.list
+----
+
 or, see the detailed instructions on manually adding repos for your version in the xref:c-sdk::sdk-release-notes.adoc#configuring-apt-repositories-debian-ubuntu[C SDK installation instructions].
 
 [NOTE]


### PR DESCRIPTION
using cosmic instead of bionic returns `404  Not Found` on 19.04

```
Err:6 http://packages.couchbase.com/ubuntu cosmic/cosmic/main amd64 Packages
  404  Not Found [IP: 13.33.147.88 80]

```