### PR TITLE
Fix incorrect batching operations example code

### DIFF
--- a/modules/ROOT/pages/document-operations.adoc
+++ b/modules/ROOT/pages/document-operations.adoc
@@ -175,7 +175,7 @@ baz => 2hcxy0srv8
 .Retrieving multiple documents
 [source,php]
 ----
-$results = $bucket->upsert(array("foo", "bar", "baz"));
+$results = $bucket->get(array("foo", "bar", "baz"));
     foreach ($results as $docid => $metadoc) {
     // Each document itself has a 'propname'
     echo "Result for $docid\n";


### PR DESCRIPTION
The example for retrieving multiple documents should use `get` not `upsert`