### PR TITLE
Add docs for Threshold and Orphan Response Logging

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -31,6 +31,7 @@ Couchbase PHP SDK
 .Errors & Diagnostics
 * xref:howtos:collecting-information-and-logging.adoc[Logging]
 // * xref:howtos:health-check.adoc[Health Check]
+* xref:howtos:slow-operations-logging.adoc[Slow Operations Logging]
 
 .Learn
 * xref:concept-docs:concepts.adoc[Overview]

--- a/modules/howtos/examples/orphan-logging.php
+++ b/modules/howtos/examples/orphan-logging.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Make sure log level is high enough to display tracing messages
+ */
+ini_set("couchbase.log_level", "INFO");
+
+use Couchbase\Cluster;
+use Couchbase\ClusterOptions;
+use Couchbase\TimeoutException;
+use Couchbase\UpsertOptions;
+
+$options = new ClusterOptions();
+$options->credentials("Administrator", "password");
+
+// #tag::orphanLogging[]
+$connectionString = "couchbase://127.0.0.1?" .
+    "tracing_orphaned_queue_flush_interval=5&"; /* every 5 seconds */
+
+$cluster = new Cluster($connectionString, $options);
+$bucket = $cluster->bucket("travel-sample");
+$collection = $bucket->defaultCollection();
+// #end::orphanLogging[]
+
+// #tag::orphanTimeout[]
+/*
+ * Create a new document
+ */
+$document = ["answer" => 42, "updated_at" => date("r")];
+$collection->upsert("foo", $document);
+
+/*
+ * Replace the document with a big body and very small deadline which should trigger a 
+ * client-side timeout, in which case the server response will be reported as orphan
+ */
+$options = new UpsertOptions();
+$options->timeout(1);
+/*
+ * Generate a document with 10M payload, that should be unfriendly to the compressing function
+ * and longer to process on the server side
+ */
+$document = ["noise" => base64_encode(random_bytes(15_000_000))];
+$numberOfTimeouts = 0;
+while (true) {
+    try {
+        $collection->upsert("foo", $document, $options);
+    } catch (TimeoutException $e) {
+        $numberOfTimeouts++;
+        if ($numberOfTimeouts > 3) {
+            break;
+        }
+    }
+}
+// #end::orphanTimeout[]
+
+/*
+ * Messages like one below will appear in the log for the orphaned response
+ *
+ * [cb,WARN] (tracer L:147 I:2929787644) Orphan responses observed: {"count":2,"service":"kv","top":[{"last_local_address":"127.0.0.1:41210","last_local_id":"aa562ed8aea102fc/a4a9305660272565","last_operation_id":"0x11","last_remote_address":"127.0.0.1:11210","operation_name":"upsert","server_us":0,"total_us":34904},{"last_local_address":"127.0.0.1:41210","last_local_id":"aa562ed8aea102fc/a4a9305660272565","last_operation_id":"0xb","last_remote_address":"127.0.0.1:11210","operation_name":"upsert","server_us":0,"total_us":32195}]}
+ */

--- a/modules/howtos/examples/orphan-logging.php
+++ b/modules/howtos/examples/orphan-logging.php
@@ -15,16 +15,16 @@ use Couchbase\UpsertOptions;
 $options = new ClusterOptions();
 $options->credentials("Administrator", "password");
 
-// #tag::orphanLogging[]
+// tag::orphanLogging[]
 $connectionString = "couchbase://127.0.0.1?" .
     "tracing_orphaned_queue_flush_interval=5&"; /* every 5 seconds */
 
 $cluster = new Cluster($connectionString, $options);
 $bucket = $cluster->bucket("travel-sample");
 $collection = $bucket->defaultCollection();
-// #end::orphanLogging[]
+// end::orphanLogging[]
 
-// #tag::orphanTimeout[]
+// tag::orphanTimeout[]
 /*
  * Create a new document
  */
@@ -53,7 +53,7 @@ while (true) {
         }
     }
 }
-// #end::orphanTimeout[]
+// end::orphanTimeout[]
 
 /*
  * Messages like one below will appear in the log for the orphaned response

--- a/modules/howtos/examples/threshold-logging.php
+++ b/modules/howtos/examples/threshold-logging.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Make sure log level is high enough to display tracing messages
+ */
+// #tag::logLevel[]
+ini_set("couchbase.log_level", "INFO");
+// #end::logLevel[]
+
+use Couchbase\Cluster;
+use Couchbase\ClusterOptions;
+use Couchbase\TimeoutException;
+use Couchbase\UpsertOptions;
+
+$options = new ClusterOptions();
+$options->credentials("Administrator", "password");
+
+// #tag::thresholdLogging[]
+$connectionString = "couchbase://127.0.0.1?" .
+    "tracing_threshold_queue_flush_interval=3&" . /* every 3 seconds */
+    "tracing_threshold_kv=0.01"; /* 10 milliseconds */
+
+$cluster = new Cluster($connectionString, $options);
+$bucket = $cluster->bucket("travel-sample");
+$collection = $bucket->defaultCollection();
+// #end::thresholdLogging[]
+
+// #tag::thresholdLongProcessing[]
+/*
+ * Create a new document
+ */
+$document = ["answer" => 42, "updated_at" => date("r")];
+$collection->upsert("foo", $document);
+
+/*
+ * Replace the document with a big body and very small deadline which should trigger a 
+ * client-side timeout, in which case the server response will be reported as orphan
+ */
+$options = new UpsertOptions();
+$options->timeout(1);
+/*
+ * Generate a document with 10M payload, that should be unfriendly to the compressing function
+ * and longer to process on the server side
+ */
+$document = ["noise" => base64_encode(random_bytes(15_000_000))];
+$numberOfTimeouts = 0;
+while (true) {
+    try {
+        $collection->upsert("foo", $document, $options);
+    } catch (TimeoutException $e) {
+        $numberOfTimeouts++;
+        if ($numberOfTimeouts > 3) {
+            break;
+        }
+    }
+}
+// #end::thresholdLongProcessing[]
+
+/*
+ * Threshold reports will be written like the following
+ *
+ * [cb,INFO] (tracer L:149 I:2929787644) Operations over threshold: {"count":14,"service":"kv","top":[{"operation_name":"php/upsert","total_us":537133},{"operation_name":"php/upsert","total_us":513483},{"operation_name":"php/upsert","total_us":510245},{"operation_name":"php/upsert","total_us":500094},{"last_local_address":"127.0.0.1:41210","last_local_id":"aa562ed8aea102fc/a4a9305660272565","last_operation_id":"0x3","last_remote_address":"127.0.0.1:11210","operation_name":"upsert","server_us":150315,"total_us":320528},{"last_local_address":"127.0.0.1:41210","last_local_id":"aa562ed8aea102fc/a4a9305660272565","last_operation_id":"0x2","last_remote_address":"127.0.0.1:11210","operation_name":"upsert","server_us":126118,"total_us":317381},{"last_local_address":"127.0.0.1:41210","last_local_id":"aa562ed8aea102fc/a4a9305660272565","last_operation_id":"0x4","last_remote_address":"127.0.0.1:11210","operation_name":"upsert","server_us":149572,"total_us":311246},{"operation_name":"php/request_encoding","total_us":200289}]}
+ */

--- a/modules/howtos/examples/threshold-logging.php
+++ b/modules/howtos/examples/threshold-logging.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 /*
  * Make sure log level is high enough to display tracing messages
  */
-// #tag::logLevel[]
+// tag::logLevel[]
 ini_set("couchbase.log_level", "INFO");
-// #end::logLevel[]
+// end::logLevel[]
 
 use Couchbase\Cluster;
 use Couchbase\ClusterOptions;
@@ -17,7 +17,7 @@ use Couchbase\UpsertOptions;
 $options = new ClusterOptions();
 $options->credentials("Administrator", "password");
 
-// #tag::thresholdLogging[]
+// tag::thresholdLogging[]
 $connectionString = "couchbase://127.0.0.1?" .
     "tracing_threshold_queue_flush_interval=3&" . /* every 3 seconds */
     "tracing_threshold_kv=0.01"; /* 10 milliseconds */
@@ -25,9 +25,9 @@ $connectionString = "couchbase://127.0.0.1?" .
 $cluster = new Cluster($connectionString, $options);
 $bucket = $cluster->bucket("travel-sample");
 $collection = $bucket->defaultCollection();
-// #end::thresholdLogging[]
+// end::thresholdLogging[]
 
-// #tag::thresholdLongProcessing[]
+// tag::thresholdLongProcessing[]
 /*
  * Create a new document
  */
@@ -56,7 +56,7 @@ while (true) {
         }
     }
 }
-// #end::thresholdLongProcessing[]
+// end::thresholdLongProcessing[]
 
 /*
  * Threshold reports will be written like the following

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -4,7 +4,7 @@
 
 [abstract]
 Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
-Change the settings to alter how much information you collect
+Change the settings to alter how much information you collect.
 
 To improve debuggability certain metrics are automatically measured and logged.
 These include slow queries, responses taking beyond a certain threshold, and orphaned responses.
@@ -30,7 +30,7 @@ Next, add the tracer settings to the connection when initialising a cluster:
 include::example$threshold-logging.php[tag=thresholdLogging]
 ----
 
-This will set our threshold for key/value operations to 10 milliseconds, and log the found operations every 3 seconds.
+This will set our threshold for key-value operations to 10 milliseconds, and log the found operations every 3 seconds.
 
 Here is an example that shows upserting a document that causes longer processing on the server side.
 
@@ -76,18 +76,19 @@ You should expect to see output in JSON format in the logs for operations over t
 }
 ----
 
-The `count` represents the total amount of recorded items in each interval per service, which in this case is the `kv` service. You can also see more information about each item/operation in the `top` array.
+The `count` represents the total amount of recorded items in each interval per service, which in this case is the `KV` service. You can also see more information about each item/operation in the `top` array.
 
 To see all the available options for the tracing settings refer to the <<tracing_settings, Tracing Options>> section of this guide.
+
 
 == Orphaned Response Reporting
 
 Orphan response reporting acts as an auxiliary tool to the tracing and metrics capabilities. 
-It does not expose an external API to the application and is very focussed on its feature set.
+It does not expose an external API to the application and is very focused on its feature set.
 
 The way it works is that every time a response is in the process of being completed, 
 when the SDK detects that the original caller is not listening anymore (likely because of a timeout), 
-it will send this “orphan” response to a reporting utility which then aggregates it and in regular intervals logs them in a specific format.
+it will send this “orphan” response to a reporting utility which then aggregates it. and at regular intervals logs them in a specific format.
 
 When the user then sees timeouts in their logs, they can go look at the output of the orphan reporter and correlate certain properties that aid debugging in production. 
 For example, if a single node is slow but the rest of the cluster is responsive, this would be visible from orphan reporting.

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -7,137 +7,78 @@ Tracing information on slow operations can be found in the logs as threshold log
 Change the settings to alter how much information you collect
 
 To improve debuggability certain metrics are automatically measured and logged.
-These include slow queries, responses taking beyond a certain threshold, and orphanned responses.
-
-
-== Observability Metrics
-
-Individual request traces present a very specific (and isolated) view of the system. 
-In addition, it also makes sense to capture information that aggregates request data (i.e. requests per second), 
-but also data which is not tied to a specific request at all (i.e. resource utilization).
-
-The deployment situation itself is similar to the tracer: either applications already have a metrics infrastructure in place or they don’t. 
-The difference is that exposing some kind of metrics is much more common than request based tracing, 
-because most production deployments at least monitor CPU usage etc.
-
-Metrics fall into the following categories:
-
-* Request/Response Metrics (such as requests per second).
-* SDK Metrics (such as how many open collections, various queue lengths).
-* System Metrics (such as cpu usage, garbage collection performance).
-
-
-
-== Configuring Metrics Logging
-
-The information logged can be configured, although configurability does vary slightly between SDKs.
-
-// Please add (here, and further down) the settings info that users need here for your SDK  :)
- 
-Advanced users can build their own implementations of the interface:
-
-[source,java]
-----
-interface Meter {
-     Counter counter(String name, Map<String, String> tags)
-     ValueRecorder valueRecorder(String name, Map<String, String> tags)
-}
-
-interface Counter {
-    void incrementBy(ulong number)
-}
-
-interface ValueRecorder {
-    void recordValue(ulong value)
-}
-----
-
-// The different Meter implementation names are heavily based on their _OpenTelemetry_ counterparts.
-
-At each emit/log interval, the AggregatingMeter outputs a JSON structure that is very similar to the `ThresholdRequestTracer` or the `OrphanResponseReporter`.
-The default value for the `emitInterval` is 600 seconds (10 minutes).
-
-==== JSON Output Format & Logging
-
-The overall structure looks like this (here prettified for readability):
-
-[source,json]
-----
-{
-  “meta”: {
-	“emit_interval_s”: 600,
-  }
-  “<service-a>”: {
-    “<node-a>” {
-      “total_count”: 1234,
-      “percentiles_us”: {
-        “50.0”: 5,
-        “90.0”: 10,
-        “99.0”: 33,
-        “99.9”: 55,
-        “100.0”: 101,
-      }
-    }
-  },
-}
-----
-
-For each service and each node, the total count and the latency percentiles are reported. 
-This will help during debugging to get a decent idea of the latency distribution across services and nodes. 
-For more sophisticated grouping and aggregations, users should use the forthcoming `OpenTelemetryMeter`, or a custom implementation.
-
-The `emit_interval_s` is reported in the meta section of the JSON output since to calculate the ops/s the `total_count` needs to be divided by the `emit_interval_s`. 
-Since the configuration property is not always available when debugging logs it is included to make it simple.
-
+These include slow queries, responses taking beyond a certain threshold, and orphaned responses.
 
 == Threshold Logging Reporting
 
 Threshold logging is the recording of slow operations -- useful for diagnosing when and where problems occur in a distributed environment.
 
-
 === Configuring Threshold Logging
+To configure threshold logging with PHP SDK 3.x you will need to set the tracer configuration via the cluster connection string.
 
-To configure threshold logging, adjust the xref:ref:client-settings.adoc#general-options[ThresholdRequestTracer].
-You should expect to see output in JSON format in the logs for the services encountering problems:
+Before setting this up, however, you must ensure that your log level is high enough to display tracing messages.
 
-[source,json]
+[source,php]
 ----
-{
-  "<service-a>": {
-    "total_count": 1234,
-    "top_requests": [{<entry>}, {<entry>},...]
-  },
-  "<service-b>": {
-    "total_count": 1234,
-    "top_requests": [{<entry>}, {<entry>},...]
-  },
+include::example$threshold-logging.php[tag=logLevel]
+----
+
+Next, add the tracer settings to the connection when initialising a cluster:
+
+[source,php]
+----
+include::example$threshold-logging.php[tag=thresholdLogging]
+----
+
+This will set our threshold for key/value operations to 10 milliseconds, and log the found operations every 3 seconds.
+
+Here is an example that shows upserting a document that causes longer processing on the server side.
+
+[source,php]
+----
+include::example$threshold-logging.php[tag=thresholdLongProcessing]
+----
+
+You should expect to see output in JSON format in the logs for operations over the specified threshold (prettified for readability):
+
+[source, json]
+----
+[cb,INFO] (tracer L:149 I:1734870558) Operations over threshold: {
+   "count":5,
+   "service":"kv",
+   "top":[
+      {
+         "operation_name":"php/upsert",
+         "total_us":1584965
+      },
+      {
+         "last_local_address":"127.0.0.1:55956",
+         "last_local_id":"3918037d7eb01092/c14128c7238454cb",
+         "last_operation_id":"0x2",
+         "last_remote_address":"127.0.0.1:11210",
+         "operation_name":"upsert",
+         "server_us":153489,
+         "total_us":1479441
+      },
+      {
+         "operation_name":"php/request_encoding",
+         "total_us":78730
+      },
+      {
+         "operation_name":"php/request_encoding",
+         "total_us":75922
+      },
+      {
+         "operation_name":"php/upsert",
+         "total_us":10862
+      }
+   ]
 }
 ----
 
-The `total_count` represents the total amount of over-threshold recorded items in each interval per service. 
-The number of entries in “top_requests” is configured by the `sampleSize`. 
-The service placeholder is replaced with each service -- “kv”, “query”, etc. 
-Each entry looks like this, with all fields populated:
+The `count` represents the total amount of recorded items in each interval per service, which in this case is the `kv` service. You can also see more information about each item/operation in the `top` array.
 
-[source,json]
-----
-{
-  "total_duration_us": 1200,
-  "encode_duration_us": 100,
-  "last_dispatch_duration_us": 40,
-  "total_dispatch_duration_us": 40,
-  "last_server_duration_us": 2,
-  "operation_name": "upsert",
-  "last_local_id": "66388CF5BFCF7522/18CC8791579B567C,
-  "operation_id": "0x23",
-  "last_local_socket": "10.211.55.3:52450",
-  "last_remote_socket": "10.112.180.101:11210"
-}
-----
-
-If a field is not present (because for example dispatch did not happen), it will not be included. 
-
-
+To see all the available options for the tracing settings refer to the <<tracing_settings, Tracing Options>> section of this guide.
 
 == Orphaned Response Reporting
 
@@ -153,45 +94,72 @@ For example, if a single node is slow but the rest of the cluster is responsive,
 
 === Configuring Orphan Logging
 
-The OrphanResponseReporter is very similar in principle to the ThresholdRequestTracer, 
-but instead of tracking responses which are over a specific threshold it tracks those responses which are “orphaned”. 
+Configuring orphan logging is very similar to how we configured the threshold logging, the only difference is the property passed to the cluster connection string:
 
-The `emitInterval` and `sampleSize` can be adjusted (defaults are 10s and 10 samples per service, respectively).
-The overall structure looks like this (here prettified for readability):
-
-[source,json]
+[source,php]
 ----
-{
-  “<service-a>”: {
-    “total_count”: 1234,
-    “top_requests”: [{<entry>}, {<entry>},...]
-  },
-  “<service-b>”: {
-    “total_count”: 1234,
-    “top_requests”: [{<entry>}, {<entry>},...]
-  },
+include::example$orphan-logging.php[tag=orphanLogging]
+----
+
+The same code example from the threshold logging section can be used to demonstrate orphaned responses.
+
+[source,php]
+----
+include::example$orphan-logging.php[tag=orphanTimeout]
+----
+
+The expected output should be something similar to the log below:
+
+[source, json]
+----
+[cb,WARN] (tracer L:147 I:4044469160) Orphan responses observed: {
+   "count":2,
+   "service":"kv",
+   "top":[
+      {
+         "last_local_address":"127.0.0.1:55653",
+         "last_local_id":"fe4cb476e16ce16b/91c55f8ed6e3f1ae",
+         "last_operation_id":"0x6",
+         "last_remote_address":"127.0.0.1:11210",
+         "operation_name":"upsert",
+         "server_us":0,
+         "total_us":476244
+      },
+      {
+         "last_local_address":"127.0.0.1:55653",
+         "last_local_id":"fe4cb476e16ce16b/91c55f8ed6e3f1ae",
+         "last_operation_id":"0x9",
+         "last_remote_address":"127.0.0.1:11210",
+         "operation_name":"upsert",
+         "server_us":0,
+         "total_us":173575
+      }
+   ]
 }
 ----
 
-The total_count represents the total amount of  recorded items in each interval per service. 
-The number of entries in “top_requests” is configured by the sampleSize. The service placeholder is replaced with each service, i.e. “kv”, “query” etc. 
-Each entry looks like this, with all fields populated:
+[#tracing_settings]
+== Tracing Options
 
-[source,json]
-----
-{
-  "total_duration_us": 1200,
-  "encode_duration_us": 100,
-  "last_dispatch_duration_us": 40,
-  "total_dispatch_duration_us": 40,
-  "last_server_duration_us": 2,
-  “timeout_ms”: 75000,
-  "operation_name": "upsert",
-  "last_local_id": "66388CF5BFCF7522/18CC8791579B567C,
-  "operation_id": "0x23",
-  "last_local_socket": "10.211.55.3:52450",
-  "last_remote_socket": "10.112.180.101:11210"
-}
-----
+The table below describes all the allowed properties that can be set for tracing and their default values.
 
-If a field is not present (because for example dispatch did not happen), it will not be included.
+.Allowed Tracer Properties
+[.table-merge-cells] 
+[cols="1,1,1, 1"] 
+|===
+| Key | Type | Default | Description
+
+| *enable_tracing*                         | bool     |    true | Activate/deactivate end-to-end tracing.
+| *tracing_orphaned_queue_size*            | int      |     128 | Size of orphaned spans queue in default tracer.
+| *tracing_orphaned_queue_flush_interval*  | duration |    10.0 | Flush interval for orphaned spans queue in default tracer.
+| *tracing_threshold_queue_size*           | int      |     128 | Size of threshold queue in default tracer.
+| *tracing_threshold_queue_flush_interval* | duration |    10.0 | Flush interval for spans with total time over threshold in default tracer.
+| *tracing_threshold_kv*                   | duration |     0.5 | Minimum time for the tracing span of KV service to be considered by threshold tracer.
+| *tracing_threshold_query*                | duration |     1.0 | Minimum time for the tracing span of N1QL service to be considered by threshold tracer.
+| *tracing_threshold_view*                 | duration |     1.0 | Minimum time for the tracing span of VIEW service to be considered by threshold tracer.
+| *tracing_threshold_search*               | duration |     1.0 | Minimum time for the tracing span of FTS service to be considered by threshold tracer.
+| *tracing_threshold_analytics*            | duration |     1.0 | Minimum time for the tracing span of ANALYTICS service to be considered by threshold tracer.
+
+|===
+
+The duration properties are given in *seconds* with fractions after floating point (e.g. "2.5" is 2 seconds and 500 milliseconds).


### PR DESCRIPTION
This PR will add the missing Threshold and Orphan Response Logging page to the PHP SDK 3.1 docs.
Uses the PHP example provided by Sergey to demonstrate both types of logging.