### PR TITLE
DOC-9863 quickfixes (after forum issue)

### DIFF
--- a/modules/howtos/examples/query.php
+++ b/modules/howtos/examples/query.php
@@ -46,7 +46,9 @@ $idx = 1;
 foreach ($res->rows() as $row) {
     printf("%d. %s, \"%s\"\n", $idx++, $row['country'], $row['name']);
 }
+// tag::metrics[]
 printf("Execution Time: %d\n", $res->metaData()->metrics()['executionTime']);
+// end::metrics[]
 
 // NOTE: This currently fails with Couchbase Internal Server error.
 // Server issue tracked here: https://issues.couchbase.com/browse/MB-46876

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -63,6 +63,13 @@ In most cases your query will return more than one result, and you may be lookin
 include::example$query.php[tag=results]
 ----
 
+You can also get metrics for your query.
+See the https://docs.couchbase.com/sdk-api/couchbase-php-client-3.2.2/classes/Couchbase-QueryMetaData.html#method_metrics[QueryMetaData API docs] for further details.
+
+[source,php]
+----
+include::example$query.php[tag=metrics]
+----
 
 == Scan Consistency
 

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -138,7 +138,11 @@ The `BinaryCollection` mentioned above could be retrieved from the regular colle
 
 ==== Query
 
-Ib SDK 3.x, the API for Query was improved and now it is more consistent with other endpoints.
+In SDK 3.x, the API for Query was improved and now it is more consistent with other endpoints.
+
+NOTE: In particular, `->rows()` is now a method rather than a property,
+and returns an array of fields to index with `['field-name']` instead of
+an object with custom property names for each field.
 
 .SDK 2
 [source,php]


### PR DESCRIPTION
From the specific queries in https://forums.couchbase.com/t/how-to-access-resultcount-in-n1ql-query-in-php-sdk/33093/4

* link to Query Metrics SDK API docs
* mention specific changes to Query ->rows() methods more explicitly.

Note that https://docs.couchbase.com/sdk-api/couchbase-php-client-3.2.2/classes/Couchbase-QueryResult.html#method_metaData doesn't seem to mention *Result Count* so doesn't really answer the questioners original question.

Is that something for SDK engg to add to SDK API and/or us in Docs to document more fully?