### PR TITLE
Doc 9912 4.0 migration / transactions docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM php:8.1-bullseye
+
+LABEL org.opencontainers.image.authors="Ray Cardillo <ray.cardillo@couchbase.com>"
+
+ENV container docker
+
+RUN mkdir /app
+WORKDIR /app
+
+RUN apt-get update -y \
+    && \
+    apt-get install -y \
+    git cmake build-essential \
+    software-properties-common \
+    libzip-dev zip \
+    wget curl jq \
+    ruby gnupg2  \
+    sed vim \
+    openssl libssl-dev
+
+RUN git clone --recurse-submodules https://github.com/couchbaselabs/couchbase-php-client.git
+
+WORKDIR /app/couchbase-php-client
+
+# For testing PRs
+#RUN git fetch origin pull/6/head \
+#    && \
+#    git checkout -b pullrequest FETCH_HEAD
+
+ENV CB_PHP_PREFIX=/usr/local
+
+RUN ./bin/build
+RUN ./bin/package
+
+RUN pecl install ./couchbase-4.0.0.tgz \
+    && \
+    docker-php-ext-enable couchbase
+
+# THE REST IS FOR REFERENCE
+
+# RUN composer install
+
+# Clear config cache
+# RUN php artisan config:clear
+
+# Set the entrypoint
+ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+
+services:
+  cb-php-sdk:
+    build: .
+    depends_on:
+      - db
+    container_name: cb-php-sdk
+    entrypoint: [ "/bin/bash", "-l", "-c" ]
+    volumes:
+      - .:/docs-sdk-php
+
+  db:
+    image: build-docker.couchbase.com:443/couchbase/server-internal:7.1.0-2549
+    ports:
+      - "8091-8095:8091-8095"
+      - "11210:11210"
+    expose: # expose ports 8091 & 8094 to other containers (mainly for backend)
+      - "8091"
+      - "8092"
+      - "8093"
+      - "8094"
+      - "8095"
+      - "11210"
+    container_name: couchbase-db

--- a/modules/howtos/examples/transactions-example.php
+++ b/modules/howtos/examples/transactions-example.php
@@ -1,0 +1,489 @@
+<?php
+
+require_once 'Couchbase/autoload.php';
+
+use \Couchbase\ClusterOptions;
+use \Couchbase\Cluster;
+use \Couchbase\TransactionsConfiguration;
+use Couchbase\TransactionAttemptContext;
+use Couchbase\TransactionQueryOptions;
+use \Couchbase\DurabilityLevel;
+use \Couchbase\QueryOptions;
+use \Couchbase\QueryScanConsistency;
+use \Couchbase\MutationState;
+
+$CB_USER = getenv('CB_USER') ?: 'Administrator';
+$CB_PASS = getenv('CB_PASS') ?: 'password';
+$CB_HOST = getenv('CB_HOST') ?: 'couchbase://db';
+$durabilityLevel = Couchbase\DurabilityLevel::NONE; // TODO
+
+// tag::config[]
+$options = new ClusterOptions();
+$options->credentials($CB_USER, $CB_PASS);
+
+$transactions_configuration = new TransactionsConfiguration();
+$transactions_configuration->durabilityLevel($durabilityLevel); // Couchbase\DurabilityLevel::PERSIST_TO_MAJORITY etc.
+$options->transactionsOptions($transactions_configuration);
+
+$cluster = new Cluster($CB_HOST, $options);
+// end::config[]
+
+// tag::bucket[]
+// get a reference to our bucket
+$bucket = $cluster->bucket('travel-sample');
+// end::bucket[]
+
+// tag::collection[]
+// get a reference to a collection
+$collection = $bucket->scope('inventory')->collection('airline');
+// end::collection[]
+  
+// tag::default-collection[]
+// get a reference to the default collection, required for older Couchbase server versions
+$collection_default = $bucket->defaultCollection();
+// end::default-collection[]
+
+function removeOrWarn($collection, $doc) {
+  try {
+    $collection->remove($doc);
+  }
+  catch (\Couchbase\Exception\DocumentNotFoundException $e) {
+    echo "Document does not exist.\n";
+  }
+}
+
+$testDoc = 'foo';
+removeOrWarn($collection, $testDoc);
+removeOrWarn($collection, 'doc-c');
+removeOrWarn($collection, 'docId');
+$collection->upsert('doc-a', []);
+$collection->upsert('doc-b', []);
+
+
+try {
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection, $testDoc) {
+      $ctx->insert($collection, $testDoc, "hello");
+    }
+  );
+}
+catch (\Exception $e) {
+  echo "Failed to insert: $e\n";
+}
+
+// tag::create[]
+try {
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) {
+    // `$ctx` is a TransactionAttemptContext which permits getting, inserting,
+    // removing and replacing documents, performing N1QL queries, etc.
+    // … Your transaction logic here …
+    // Committing is implicit at the end of the lambda.
+    });
+}
+catch (\Couchbase\Exception\TransactionOperationFailedException $e) {
+    echo "Transaction did not reach commit point: $e\n";
+}
+catch (\Couchbase\Exception\TransactionException $e) { 
+// TODO check is this equivalent to TransactionCommitAmbiguousError as per Node examples?
+  echo "Transaction possibly committed: $e\n";
+}
+// end::create[]
+
+// tag::examples[]
+
+try {
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection) {
+      // Inserting a doc:
+      $ctx->insert($collection, 'doc-a', []);
+
+      // Getting documents:
+      $docA = $ctx->get($collection, 'doc-a');
+
+      // Replacing a doc:
+      $docB = $ctx->get($collection, 'doc-b');
+      $content = $docB->content;
+      $newContent = array_merge(
+        ["transactions" => "are awesome"],
+        $content);
+      
+      $ctx->replace($docB, $newContent);
+
+      // Removing a doc:
+      $docC = $ctx->get($collection, 'doc-c');
+      $ctx->remove($docC);
+
+      // Performing a SELECT N1QL query against a scope:
+      $qr = $ctx->query('SELECT * FROM hotel WHERE country = $1',
+        [ "scope" => "inventory",
+          "parameters" => ["United Kingdom"]
+      ]);
+      echo $qr->rows();
+
+      $ctx->query('UPDATE route SET airlineid = $1 WHERE airline = $2',
+        [ "scope" => "inventory",
+          "parameters" => ['airline_137', 'AF'] ] );
+    });
+}
+catch (\Couchbase\Exception\TransactionOperationFailedException $e) {
+    echo "Transaction did not reach commit point: $e\n";
+}
+catch (\Couchbase\Exception\TransactionException $e) { 
+// TODO check is this equivalent to TransactionCommitAmbiguousError as per Node examples?
+  echo "Transaction possibly committed: $e\n";
+}
+// end::examples[]
+
+// execute other examples
+getExample($cluster, $collection);
+getReadOwnWritesExample($cluster, $collection);
+replaceExample($cluster, $collection);
+removeExample($cluster, $collection);
+insertExample($cluster, $collection);
+queryExamples($cluster, $collection);
+queryInsert($cluster, $collection);
+queryRYOW($cluster);
+queryOptions($cluster);
+querySingle($cluster);
+
+# TODO set data up to run these examples fully
+# playerHitsMonster(42, "arthur", "vogon", $cluster, $collection);
+# rollback(...)
+# rollbackCause(...)
+
+function getExample($cluster, $collection) {
+  echo "getExample\n";
+  // tag::get[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection) { 
+      $docA = $ctx->get($collection, "doc-a");
+    });
+  // end::get[]
+  // TODO: should this show nullable/optional in an example?
+}
+
+function getReadOwnWritesExample($cluster, $collection) {
+  // tag::getReadOwnWrites[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection) { 
+    $docId = 'docId';
+    $ctx->insert($collection, $docId, []);
+
+    $doc = $ctx->get($collection, $docId);
+  });
+  // end::getReadOwnWrites[]
+}
+
+function replaceExample($cluster, $collection) {
+  // tag::replace[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection) {
+      $doc = $ctx->get($collection, "doc-b");
+      $content = $doc->content();
+      $newContent = array_merge(
+        ["transactions" => "are awesome"],
+        $content);
+      
+      $ctx->replace($doc, $newContent);
+  });
+  // end::replace[]
+}
+
+function removeExample($cluster, $collection) {
+  // tag::remove[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection) {
+      $doc = $ctx->get($collection, "docId");
+      $ctx->remove($doc);
+  });
+  // end::remove[]
+}
+
+function insertExample($cluster, $collection) {
+  // tag::insert[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection) { 
+      $adoc = $ctx->insert($collection, "docId", []);
+  });
+  // end::insert[]
+}
+
+function queryExamples($cluster) {
+  // tag::queryExamplesSelect[]
+  $inventory = $cluster->bucket('travel-sample')->scope('inventory');
+
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) { 
+      $st = "SELECT * FROM `travel-sample`.inventory.hotel WHERE country = $1";
+      $qr = $ctx->query(
+        $st,
+        TransactionQueryOptions::build()
+          ->positionalParameters(["United Kingdom"]));
+
+      foreach ($qr->rows() as $row) {
+        // do something
+      }
+    }
+  );
+  // end::queryExamplesSelect[]
+
+  // tag::queryExamplesUpdate[]
+  $hotelChain = 'http://marriot%';
+  $country = 'United States';
+  
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($hotelChain, $country) { 
+      
+      // TODO: scope parameter doesn't work
+      // $st = hotel SET price = $1 WHERE url LIKE $2 AND country = $3";
+      $st = "UPDATE `travel-sample`.inventory.hotel SET price = $1 WHERE url LIKE $2 AND country = $3";
+      $qr = $ctx->query(
+        $st,
+        TransactionQueryOptions::build()
+          ->positionalParameters([99.99, $hotelChain, $country]));
+          // ->scopeQualifier("`travel-sample`.`inventory`"));
+
+      print_r($qr->metaData()->metrics());
+      if ($qr->metaData()->metrics()["mutationCount"] != 2) {
+        // throw new \Exception("Mutation count not the expected amount.");
+        echo "WARN: Mutation count not the expected amount.\n";
+      }
+    }
+  );
+  // end::queryExamplesUpdate[]
+
+  // tag::queryExamplesComplex[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($hotelChain, $country) { 
+      // Find all hotels of the chain
+      $qr = $ctx->query(
+        'SELECT reviews FROM `travel-sample`.inventory.hotel WHERE url LIKE $1 AND country = $2',
+        TransactionQueryOptions::build()
+          ->positionalParameters([$hotelChain, $country]));
+          // ->scopeQualifier("`travel-sample`.`inventory`"));
+
+      // This function (not provided here) will use a trained machine learning model to provide a
+      // suitable price based on recent customer reviews.
+      function priceFromRecentReviews(Couchbase\QueryResult $qr) {
+          // this would call a trained ML model to get the best price
+          return 99.98;
+      }
+      $updatedPrice = priceFromRecentReviews($qr);
+
+      // Set the price of all hotels in the chain
+      $ctx->query(
+        'UPDATE `travel-sample`.inventory.hotel SET price = $1 WHERE url LIKE $2 AND country = $3',
+        TransactionQueryOptions::build()
+          ->positionalParameters([$updatedPrice, $hotelChain, $country]));
+          // ->scopeQualifier("`travel-sample`.`inventory`"));
+    }
+  );
+  // end::queryExamplesComplex[]
+}
+
+function queryInsert($cluster) {
+  // tag::queryInsert[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) { 
+      $ctx->query("INSERT INTO `travel-sample`.inventory.airline VALUES ('doc-c', {'hello':'world'})"); // <1>
+      $st = "SELECT `default`.* FROM `travel-sample`.inventory.airline WHERE META().id = 'doc-c'"; // <2>
+      $qr = $ctx->query($st);
+  });
+  // end::queryInsert[]
+}
+
+function queryRYOW($cluster) {
+  // tag::queryRYOW[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) {
+      $qr = $ctx->query("UPDATE `travel-sample`.inventory.hotel SET price = 99.00 WHERE name LIKE \"Marriott%\"");
+      if ($qr->metaData()->metrics()["mutationCount"] != 2) {
+        // throw new \Exception("Mutation count not the expected amount.");
+        echo "WARN: Mutation count not the expected amount.\n";
+      }
+    }
+  );
+// end::queryRYOW[]
+}
+
+function queryOptions($cluster) {
+  // tag::queryOptions[]
+
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) {
+      $txQo = TransactionQueryOptions::build()
+        ->timeout(1000)
+        ->positionalParameters(["key", "value"]);
+        
+      $ctx->query(
+        "UPSERT INTO `travel-sample`.inventory.airline VALUES ('docId', {\$1:\$2})",
+        $txQo);
+  });
+  // end::queryOptions[]
+}
+
+function querySingle($cluster) {
+  // tag::querySingle[]
+  try {
+    $cluster->transactions()->run(
+      function (TransactionAttemptContext $ctx) {
+        $bulkLoadStatement = "..."; // a bulk-loading N1QL statement not provided here
+
+        $ctx->query($bulkLoadStatement);
+    });
+  }
+  catch (\Couchbase\Exception\TransactionOperationFailedException $e) {
+    echo "Transaction did not reach commit point\n";
+  }
+  catch (\Couchbase\Exception\TransactionException $e) { 
+    echo "Transaction possibly committed\n";
+  }
+}
+// end::querySingle[]
+
+// SKIP querySingleScoped till checked Scoped examples above!
+// async function querySingleScoped() {
+//   let cluster = await getCluster()
+
+//   const bulkLoadStatement = ""  /* your statement here */
+
+//   // String bulkLoadStatement = null /* your statement here */;
+
+//   // // tag::querySingleScoped[]
+//   const travelSample = cluster.bucket("travel-sample")
+//   const inventory = travelSample.scope("inventory")
+//   // TODO: enable after implementation
+//   // cluster.transactions().query(bulkLoadStatement, {scope: inventory})
+//   // end::querySingleScoped[]
+//   // Bucket travelSample = cluster.bucket("travel-sample");
+//   // Scope inventory = travelSample.scope("inventory");
+//   // transactions.query(inventory, bulkLoadStatement);
+//   // // end::querySingleScoped[]
+// }
+
+// tag::full[]
+function playerHitsMonster($damage, $playerId, $monsterId, $cluster, $collection) {
+  try {
+    $cluster->transactions()->run(
+      function (TransactionAttemptContext $ctx) use ($damage, $playerId, $monsterId, $collection) {
+        $monsterDoc = $ctx->get($collection, $monsterId);
+        $monsterContent = $monsterDoc->content();
+        $playerDoc = $ctx->get($playerId, $monsterId);
+        $playerContent = $playerDoc->content();
+
+        $monsterHitpoints = $monsterContent["hitpoints"];
+        $monsterNewHitpoints = $monsterHitpoints - $damage;
+
+        if ($monsterNewHitpoints <= 0) {
+          // Monster is killed. The remove is just for demoing, and a more realistic
+          // example would set a "dead" flag or similar.
+          $ctx->remove($monsterDoc);
+
+          // The player earns experience for killing the monster
+          $experienceForKillingMonster = $monsterContent["experienceWhenKilled"];
+          $playerExperience = $playerContent["experience"];
+          $playerNewExperience = $playerExperience + $experienceForKillingMonster;
+          $playerNewLevel =
+            calculateLevelForExperience($playerNewExperience);
+
+          $playerContent['experience'] = $playerNewExperience;
+          $playerContent['level'] = $playerNewLevel;
+
+          $ctx->replace($playerDoc, $playerContent);
+      }
+    });
+  }
+  catch (\Couchbase\Exception\TransactionOperationFailedException $e) {
+    echo "Transaction did not reach commit point\n";
+    // The operation failed. Both the monster and the player will be untouched.
+    //
+    // Situations that can cause this would include either the monster
+    // or player not existing (as get is used), or a persistent
+    // failure to be able to commit the transaction, for example on
+    // prolonged node failure.
+  }
+  catch (\Couchbase\Exception\TransactionException $e) { 
+    // TODO check is this equivalent to TransactionCommitAmbiguousError as per Node examples?
+    // Indicates the state of a transaction ended as ambiguous and may or
+    // may not have committed successfully.
+    //
+    // Situations that may cause this would include a network or node failure
+    // after the transactions operations completed and committed, but before the
+    // commit result was returned to the client
+    echo "Transaction possibly committed\n";
+  }
+}
+// end::full[]
+
+function rollbackExample($cluster, $collection) {
+  $costOfItem = 10;
+  
+  // tag::rollback[]
+  $cluster->transactions()->run(
+    function (TransactionAttemptContext $ctx) use ($collection, $costOfItem) {
+      $customer = $ctx->get($collection, "customer-name");
+      if ($customer->content()["balance"] < $costOfItem) {
+        throw new \Error("Transaction failed, customer does not have enough funds.");
+      }
+      // else continue transaction
+  });
+  // end::rollback[]
+}
+
+class InsufficientBalanceError extends Error {}
+
+function rollbackCause($cluster, $collection) {
+  $costOfItem = 10;
+
+  // tag::rollback-cause[]
+  try {
+    $cluster->transactions()->run(
+      function (TransactionAttemptContext $ctx) use ($collection, $costOfItem) {
+        $customer = $ctx->get($collection, "customer-name");
+
+        if ($customer->content()["balance"] < $costOfItem) {
+          throw new \InsufficientBalanceError("Transaction failed, customer does not have enough funds.");
+        }
+        // else continue transaction
+    });
+  }
+  catch (\Couchbase\Exception\TransactionOperationFailedException $e) {
+    // This exception can only be thrown at the commit point, after the
+    // BalanceInsufficient logic has been passed
+  }
+  catch (InsufficientBalanceError $e) {
+    echo "user had insufficient balance";
+  }
+  // end::rollback-cause[]
+}
+
+function completeErrorHandling($cluster, $collection) {
+  // tag::full-error-handling[]
+  try {
+    $result = $cluster->transactions()->run(
+      function (TransactionAttemptContext $ctx) use ($collection, $costOfItem) {
+        // ... transactional code here ...
+      }
+    );
+
+    // The transaction definitely reached the commit point. Unstaging
+    // the individual documents may or may not have completed
+
+    if (! $result->unstagingComplete) {
+        // In rare cases, the application may require the commit to have
+        // completed.  (Recall that the asynchronous cleanup process is
+        // still working to complete the commit.)
+        // The next step is application-dependent.
+    }
+  }
+  catch (\Couchbase\Exception\TransactionOperationFailedException $e) {
+    echo "Transaction did not reach commit point\n";
+  }
+  catch (\Couchbase\Exception\TransactionException $e) { 
+    echo "Transaction possibly committed\n";
+  }
+  // end::full-error-handling[]
+}
+
+echo "\n\nTransactions Examples completed successfully\n\n";

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -43,8 +43,6 @@ include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating
 include::example$transactions-example.php[tag=create,indent=0]
 ----
 
-// TODO: this partial may need to be reviewed
-// TODO: see https://docs.couchbase.com/java-sdk/current/howtos/distributed-acid-transactions-from-the-sdk.html#:~:text=The%20lambda%20gets%20passed%20an%20AttemptContext%20object%2C%20generally%20referred%20to%20as%20ctx%20here.
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
 
 == Examples
@@ -66,10 +64,9 @@ include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=mechanic
 
 === Replacing
 
-// TODO check PHP relevance of following
-Replacing a document requires a `ctx.get()` call first.
+Replacing a document requires a `$ctx->get()` call first.
 This is necessary so the transaction can check that the document is not involved in another transaction.
-If it is, then the transaction will handle this at the `ctx.replace()` point.
+If it is, then the transaction will handle this at the `$ctx->replace()` point.
 Generally, this involves rolling back what has been done so far, and retrying the lambda.
 Handling errors should be done through try/catch as in the example above.
 
@@ -80,8 +77,7 @@ include::example$transactions-example.php[tag=replace,indent=0]
 
 === Removing
 
-// TODO check PHP relevance of following
-As with replaces, removing a document requires a `ctx.get()` call first.
+As with replaces, removing a document requires a `$ctx->get()` call first.
 
 [source,php]
 ----
@@ -104,9 +100,7 @@ From a transaction context you may get a document:
 include::example$transactions-example.php[tag=get,indent=0]
 ----
 
-// TODO check PHP relevance of following
-`get` will cause the transaction to fail with `TransactionFailed` (after rolling back any changes, of course).
-It is provided as a convenience method so the developer does not have to check the `Optional` if the document must exist for the transaction to succeed.
+`get` will cause the transaction to fail with `TransactionOperationFailedException` (after rolling back any changes, of course).
 
 Gets will 'read your own writes', e.g. this will succeed:
 
@@ -123,7 +117,7 @@ If you already use N1QL from the PHP SDK, then its use in transactions is very s
 it returns the same `QueryResult` you are used to, and takes most of the same options.
 
 // TODO check PHP relevance of following
-You must take care to write `ctx.query()` inside the lambda however, rather than `cluster.query()` or `scope.query()`.
+You must take care to write `$ctx->query()` inside the lambda however, rather than `$cluster->query()` or `$scope->query()`.
 
 An example of SELECTing some rows from the `travel-sample` bucket:
 
@@ -132,6 +126,8 @@ An example of SELECTing some rows from the `travel-sample` bucket:
 include::example$transactions-example.php[tag=queryExamplesSelect,indent=0]
 ----
 
+// TODO the Scope reference stuff doesn't seem to work
+////
 Rather than specifying the full "`travel-sample`.inventory.hotel" name each time, it is easier to pass a reference to the inventory `Scope`:
 
 [source,php]
@@ -145,8 +141,9 @@ An example using a `Scope` for an UPDATE:
 ----
 include::example$transactions-example.php[tag=queryExamplesUpdate,indent=0]
 ----
+////
 
-And an example combining SELECTs and UPDATEs.
+Here is an example combining SELECTs and UPDATEs.
 It's possible to call regular PHP functions from the lambda, as shown here, permitting complex logic to be performed.
 Just remember that since the lambda may be called multiple times, so may the method.
 
@@ -177,7 +174,7 @@ In this example we insert a document with Key-Value, and read it with a SELECT.
 
 [source,php]
 ----
-include::example$transactions-example.php[tag=queryRyow,indent=0]
+include::example$transactions-example.php[tag=queryRYOW,indent=0]
 ----
 
 <1> As with the 'Read Your Own Writes' example, here the insert is only staged, and so it is not visible to other transactions or non-transactional actors.
@@ -185,7 +182,6 @@ include::example$transactions-example.php[tag=queryRyow,indent=0]
 
 === Query Options
 
-// TODO check PHP relevance of following
 Query options can be provided via `TransactionsQueryOptions`, which provides a subset of the options in the PHP SDK's `QueryOptions`.
 
 [source,php]
@@ -193,11 +189,11 @@ Query options can be provided via `TransactionsQueryOptions`, which provides a s
 include::example$transactions-example.php[tag=queryOptions,indent=0]
 ----
 
-// TODO: check this partial to see if it matches up across SDKs.  otherwise, make it a table?
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-options]
+// // TODO: check this partial to see if it matches up across SDKs.  otherwise, make it a table?
+// include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-options]
 
 // TODO check PHP relevance of following
-See the xref:howtos:n1ql-queries-with-sdk.adoc#query-options[QueryOptions documentation] for details on these.
+See the xref:howtos:n1ql-queries-with-sdk.adoc#query-options[QueryOptions documentation] for full details on the supported parameters.
 
 // TODO: Replace the section below with this when we ensure that the shared partials in common are truly generic.
 // include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-perf]
@@ -234,8 +230,7 @@ include::example$transactions-example.php[tag=querySingle,indent=0]
 
 == Committing
 
-// TODO check PHP relevance of following
-Committing is automatic: if there is no explicit call to `ctx.commit()` at the end of the transaction logic callback, and no exception is thrown, it will be committed.
+Committing is automatic: if there is no explicit call to `$ctx->commit()` at the end of the transaction logic callback, and no exception is thrown, it will be committed.
 Committing is automatic at the end of the code block with the transaction context.
 If no exception is thrown, it will be committed.
 If you want to rollback the transaction, simply throw an exception.
@@ -260,7 +255,6 @@ include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=example]
 include::example$transactions-example.php[tag=full,indent=0]
 ----
 
-// TODO: this partial has some Java specific things in it
 // concurrency
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
 

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -12,26 +12,20 @@ include::partial$attributes.adoc[]
 The Document class and structure has been completely removed from the API, and the returned value is now `Result`.
 Retry behaviour is more proactive, and lazy bootstrapping moves all error handling to a single place.
 
-The current PHP SDK 4.0 is also based on the xref:project-docs:compatibility.adoc#sdk3.2[SDK API 3.2 specification], and offers an entirely new backend (couchbase++) with better support for upcoming features like Distributed ACID Transactions.
+The current PHP SDK 4.0 is also based on the xref:project-docs:compatibility.adoc#sdk3.3[SDK API 3.3 specification], and offers an entirely new backend (Couchbase++) with better support for new features like Distributed ACID Transactions.
 We have increased the major version to reflect the importance of this implementation change as per https://semver.org/[semantic versioning].
 
 The intent of this migration guide is to provide detail information on the changes and what to look for while upgrading the SDK.
 
-NOTE: if you are an existing PHP SDK 3._x_ user considering migrating to SDK 4.0,
+NOTE: For the most part, migration from SDK API 2._x_ versions remains the same.
+The few 4.0-specific changes can be found at the end of this document.
+If you are an existing PHP SDK 3._x_ user considering migrating to SDK 4.0,
 you may wish to skip to the <<sdk4-specifics,SDK 4.0 specifics>> below.
 
 include::{version-server}@sdk:shared:partial$api-version.adoc[tag=api-version]
 
-// include::{version-server}@sdk:shared:partial$migration.adoc[tag=intro]
-// tag::intro[]
 
-== Fundamentals
-
-Before this guide dives into the language-specific technical component of the migration, it is important to understand the high level changes first.
-As a migration guide, this document assumes you are familiar with the previous generation of the SDK and does not re-introduce SDK API 2 concepts.
-We recommend familiarizing yourself with the new SDK first by reading at least the xref:hello-world:start-using-sdk.adoc[getting started guide], and browsing through the other chapters a little.
-
-// end::intro[]
+include::{version-server}@sdk:shared:partial$migration.adoc[tag=intro]
 
 
 include::7.1@sdk:shared:partial$migration.adoc[tag=terms]


### PR DESCRIPTION
Note that some of this work was already committed to release/4.0 as WIP, so you may prefer to look at the full files rather than diffs.

@avsej some specific things to note for transactions-example.php:

* I'm not sure which exception maps to TransactionCommitAmbiguousError, have I got that the right way round?
* scope parameter doesn't work? (have commented out some examples that call this out)
* mutationCount metric doesn’t work?
* DurabilityLevel thing we discussed last week
* have I got the wrong/old method name for the transaction configuration? (I may have committed this before Sergey updated, and need to rebuild my PHP SDL 4.0)
* Renamed $attempt to $ctx (I liked $attempt for PHP and wanted to keep, but this makes it consistent with other examples, and @maria-robobug / @programmatix  common partials work)

Changed some behaviour from Node.js version (for example pass the Cluster and Collection explicitly rather than awaiting, as I couldn't see if that was important?)