### PR TITLE
AV-35207 - Restructure Distributed ACID Transactions documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "couchbase/couchbase": "^4.0",
-        "ext-couchbase": "^4.0"
+        "couchbase/couchbase": "^4.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "047a90a8259ab5d68d59eec8da1dc090",
+    "content-hash": "fa3f142633f474874cf71c8e5c890557",
     "packages": [
         {
             "name": "couchbase/couchbase",
@@ -53,9 +53,7 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {
-        "ext-couchbase": "^4.0"
-    },
+    "platform": [],
     "platform-dev": [],
     "plugin-api-version": "2.3.0"
 }

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -14,10 +14,18 @@ Couchbase PHP SDK
 * xref:howtos:full-text-searching-with-sdk.adoc[Full Text Search]
 * xref:howtos:view-queries-with-sdk.adoc[MapReduce Views]
 
+.Transactions
+* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[How-to Guide]
+// TODO: Add Single Query and Tracing when available in PHP SDK
+//** xref:howtos:transactions-single-query.adoc[Single Query Transactions]
+//** xref:howtos:transactions-tracing.adoc[Tracing]
+* xref:concept-docs:transactions.adoc[Key Concepts]
+** xref:concept-docs:transactions-cleanup.adoc[Cleanup]
+** xref:concept-docs:transactions-error-handling.adoc[Error Handling]
+
 .Advanced Data Operations
 * xref:howtos:concurrent-async-apis.adoc[Batching]
 * xref:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations]
-* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions]
 // * xref:howtos:durability.adoc[Durability]
 * xref:howtos:transcoders-nonjson.adoc[Transcoders & Non-JSON]
 * xref:howtos:working-with-collections.adoc[Working with Collections]

--- a/modules/concept-docs/pages/transactions-cleanup.adoc
+++ b/modules/concept-docs/pages/transactions-cleanup.adoc
@@ -1,0 +1,47 @@
+= Cleanup
+:description: The SDK takes care of failed or lost transactions, using an asynchronous cleanup background task.
+:page-toclevels: 2
+:page-pagination: full
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!library-cleanup-buckets]
+
+[#tuning-cleanup]
+=== Configuring Cleanup
+
+The cleanup settings can be configured as so:
+
+[options="header"]
+|===
+|Setting|Default|Description
+|`cleanupWindow()`|60 seconds|This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents.  It is perfectly valid for the application to change this setting, which is at a conservative default.  Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
+|`disableLostAttemptCleanup()`|true|This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client.  It is strongly recommended that it is left enabled.
+|`disableClientAttemptCleanup()`|true|This thread is for cleaning up transactions created just by this client.  The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash).  It is strongly recommended that it is left enabled.
+|===
+
+== Monitoring Cleanup
+
+To monitor cleanup, increase the verbosity on the logging.
+
+//TODO: once events are available, re-add the below
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=cleanup-events,indent=0]
+//----
+//
+//`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
+//(A run is typically around every 60 seconds, with default configuration.)
+//
+//A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
+//It contains whether that attempt was successful, along with any logs relevant to the attempt.
+//
+//In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
+//With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
+//If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
+
+Please see the xref:howtos:collecting-information-and-logging.adoc[PHP SDK logging documentation] for details.

--- a/modules/concept-docs/pages/transactions-error-handling.adoc
+++ b/modules/concept-docs/pages/transactions-error-handling.adoc
@@ -1,0 +1,35 @@
+= Error Handling
+:description: Handling transaction errors with Couchbase.
+:page-toclevels: 2
+:page-pagination: prev
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error-intro]
+
+== Transaction Errors
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
+
+// TODO: Need an equivalent PHP snippet for the below
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=config-expiration,indent=0]
+//----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
+
+=== Full Error Handling Example
+
+Pulling all of the above together, this is the suggested best practice for error handling:
+
+[source,php]
+----
+include::howtos:example$transactions-example.php[tag=full-error-handling,indent=0]
+----

--- a/modules/concept-docs/pages/transactions.adoc
+++ b/modules/concept-docs/pages/transactions.adoc
@@ -1,0 +1,68 @@
+= Distributed ACID Transactions
+:description:  A high-level overview of Distributed ACID Transactions with Couchbase.
+:page-toclevels: 2
+:page-pagination: full
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+[abstract]
+{description}
+
+For a practical guide, see xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions from the PHP SDK].
+
+== Overview
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=intro]
+
+== Transaction Mechanics
+
+[source,php]
+----
+include::howtos:example$transactions-example.php[tag=create-simple,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!library-cleanup-process]
+
+== Rollback
+
+If an exception is thrown by the application from the {lambda}, then that attempt is rolled back.
+The transaction logic may or may not be retried, depending on the exception.
+
+If the transaction is not retried then it will throw an exception, and its `context()` method can be used to inspect the details of the failure.
+
+The application can use this to signal why it triggered a rollback, as so:
+
+[source,php]
+----
+include::howtos:example$transactions-example.php[tag=rollback-cause,indent=0]
+----
+
+After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the system will not try to automatically commit it at the end of the code block.
+
+== Transaction Operations
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query;!library-begin-transaction]
+
+== Concurrency with Non-Transactional Writes
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
+
+// TODO: uncomment once custom metadata collections are supported
+//== Custom Metadata Collections
+//
+//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
+//
+//[source,python]
+//----
+//include::howtos:example$transactions_example.py[tag=custom_metadata,indent=0]
+//----
+//
+//or at an individual transaction level with:
+//
+//[source,java]
+//----
+//include::howtos:example$transactions_example.py[tag=custom_metadata_per,indent=0]
+//----
+//
+//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=integrated-sdk-custom-metadata-2]

--- a/modules/concept-docs/pages/xattr.adoc
+++ b/modules/concept-docs/pages/xattr.adoc
@@ -7,15 +7,16 @@
 [abstract]
 {description}
 
-include::6.5@sdk:shared:partial$sdk-xattr-overview.adoc[tag=intro_extended_attributes]
+include::project-docs:partial$attributes.adoc[]
 
-include::6.5@sdk:shared:partial$sdk-xattr-overview.adoc[tag=using_extended_attributes]
+include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=using_extended_attributes]
 
-include::6.5@sdk:shared:partial$sdk-xattr-overview.adoc[tag=virtual_extended_attributes]
+include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=virtual_extended_attributes]
 
-[source,java]
-----
-bucket.lookupIn(key).get("$document.exptime", new SubdocOptionsBuilder().xattr(true)).execute()
-----
+// TODO: Update this to PHP
+//[source,java]
+//----
+//bucket.lookupIn(key).get("$document.exptime", new SubdocOptionsBuilder().xattr(true)).execute()
+//----
 
 // See the xref:howtos:sdk-xattr-example.adoc#virtual-extended-attributes-example[example page] for a complete code sample.

--- a/modules/howtos/examples/transactions-example.php
+++ b/modules/howtos/examples/transactions-example.php
@@ -12,11 +12,11 @@ use Couchbase\QueryOptions;
 use Couchbase\QueryScanConsistency;
 use Couchbase\MutationState;
 
+// tag::config[]
 $CB_USER = getenv('CB_USER') ?: 'Administrator';
 $CB_PASS = getenv('CB_PASS') ?: 'password';
 $CB_HOST = getenv('CB_HOST') ?: 'couchbase://localhost';
 
-// tag::config[]
 $options = new ClusterOptions();
 $options->credentials($CB_USER, $CB_PASS);
 
@@ -89,6 +89,18 @@ try {
   echo "Transaction possibly committed: $e\n";
 }
 // end::create[]
+
+echo "Running: create-simple example\n";
+// tag::create-simple[]
+$cluster->transactions()->run(
+  function (TransactionAttemptContext $ctx) use ($collection) {
+    $ctx->insert($collection, 'doc1', ['hello' => 'world']);
+
+    $doc = $ctx->get($collection, 'doc1');
+    $ctx->replace($doc, ['foo' => 'bar']);
+  }
+);
+// end::create-simple[]
 
 echo "\nRunning: examples\n";
 // tag::examples[]

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -3,6 +3,7 @@
 :navtitle: ACID Transactions
 :page-topic-type: howto
 :page-toclevels: 2
+:page-pagination: next
 
 include::project-docs:partial$attributes.adoc[]
 include::partial$acid-transactions-attributes.adoc[]
@@ -10,85 +11,101 @@ include::partial$acid-transactions-attributes.adoc[]
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=intro]
+This guide will show you examples of how to perform multi-document ACID (atomic, consistent, isolated, and durable) database transactions within your application, using the Couchbase Node.js SDK.
 
+Refer to the xref:concept-docs:transactions.adoc[Distributed ACID Transactions] concept material for a high-level overview.
 
-== Requirements
+== Prerequisites
 
-* Couchbase Server 6.6.1 or above.
-* Couchbase PHP SDK 4.0.0 or above.
+[{tabs}]
+====
+Couchbase Capella::
++
+--
+* Couchbase Capella account.
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:cloud:organizations:organization-projects-overview.adoc[Organizations & Access] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+--
+
+Couchbase Server::
++
+--
+* Couchbase Server (6.6.1 or above).
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:{version-server}@server:learn:security/roles.adoc[Roles] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+* NTP should be configured so nodes of the Couchbase cluster are in sync with time.
+--
+====
+
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
-
-== Getting Started
-
-Couchbase transactions require no additional components or services to be configured. 
-Simply install the most recent version of the SDK.
-
-== Configuration
-
-Transactions can optionally be globally configured when configuring the `Cluster`.
-For example, if you want to change the level of durability which must be attained, this can be configured as part of the connect options:
-
-[source,php]
-----
-include::example$transactions-example.php[tag=config,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
+== Creating a Transaction
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating]
-
-[source,php]
-----
-include::example$transactions-example.php[tag=create,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
-
-// Examples
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=examples-intro]
 
 [source,php]
 ----
 include::example$transactions-example.php[tag=examples,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!library-cleanup-process]
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag={lambda}-ctx]
 
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating-error]
 
-== Key-Value Mutations
+== Logging
 
-=== Replacing
+To aid troubleshooting, raise the log level on the SDK.
+// TODO: need to add logging details
+//To aid troubleshooting, each transaction maintains a list of log entries, which can be logged on failure like this:
 
-Replacing a document requires a `$ctx->get()` call first.
-This is necessary so the transaction can check that the document is not involved in another transaction.
-If it is, then the transaction will handle this at the `$ctx->replace()` point.
-Generally, this involves rolling back what has been done so far, and retrying the lambda.
-Handling errors should be done through `try/catch` as in the example <<Examples,above>>.
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=logging,indent=0]
+//----
+//
+//A failed transaction can involve dozens, even hundreds, of lines of logging, so the application may prefer to write failed transactions into a separate file.
+//
+//For convenience there is also a config option that will automatically write this programmatic log to the standard Couchbase Java logging configuration inherited from the SDK if a transaction fails.
+//This will log all lines of any failed transactions, to `WARN` level:
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=config_warn,indent=0]
+//----
+//
 
-[source,php]
-----
-include::example$transactions-example.php[tag=replace,indent=0]
-----
+Please see the xref:howtos:collecting-information-and-logging.adoc[PHP SDK logging documentation] for details.
 
-=== Removing
+== Key-Value Operations
 
-As with replaces, removing a document requires a `$ctx->get()` call first.
+You can perform transactional database operations using familiar key-value CRUD methods:
 
-[source,php]
-----
-include::example$transactions-example.php[tag=remove,indent=0]
-----
+* **C**reate - `insert()`
 
-=== Inserting
+* **R**ead - `get()`
+
+* **U**pdate - `replace()`
+
+* **D**elete - `remove()`
+
+[IMPORTANT]
+====
+As mentioned <<{lambda}-ops,previously>>, make sure your application uses the transactional key-value operations inside the {lambda} -- such as `ctx.insert()`, rather than `collection.insert()`.
+====
+
+=== Insert
+
+To insert a document within a transaction {lambda}, simply call `ctx.insert()`.
 
 [source,php]
 ----
 include::example$transactions-example.php[tag=insert,indent=0]
 ----
 
-== Key-Value Reads
+=== Get
 
 From a transaction context you may get a document:
 
@@ -99,23 +116,43 @@ include::example$transactions-example.php[tag=get,indent=0]
 
 If the document does not exist, the transaction will fail with a `TransactionFailedException` (after rolling back any changes, of course).
 
-Gets will 'read your own writes', e.g. this will succeed:
+Gets will "Read Your Own Writes", e.g. this will succeed:
 
 [source,php]
 ----
 include::example$transactions-example.php[tag=getReadOwnWrites,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query-intro;!library-begin-transaction]
+=== Replace
 
-=== Using N1QL
+Replacing a document requires a `$ctx->get()` call first.
+This is necessary so the SDK can check that the document is not involved in another transaction, and take appropriate action if so.
 
-If you already use N1QL from the PHP SDK, then its use in transactions is very similar.
+[source,php]
+----
+include::example$transactions-example.php[tag=replace,indent=0]
+----
+
+=== Remove
+
+As with replaces, removing a document requires a `$ctx->get()` call first.
+
+[source,php]
+----
+include::example$transactions-example.php[tag=remove,indent=0]
+----
+
+== {sqlpp} Queries
+
+If you already use https://www.couchbase.com/products/n1ql[{sqlpp} (formerly N1QL)], then its use in transactions is very similar.
 It returns the same `QueryResult` you are used to, and takes most of the same options.
 
-You must take care to write `$ctx->query()` inside the lambda however, rather than `$cluster->query()` or `$scope->query()`.
+[IMPORTANT]
+====
+As mentioned <<lambda-ops,previously>>, make sure your application uses the transactional query operations inside the {lambda} -- such as `ctx.query()`, rather than `cluster.query()` or `scope.query()`.
+====
 
-An example of selecting some rows from the `travel-sample` bucket:
+Here is an example of selecting some rows from the `travel-sample` bucket:
 
 [source,php]
 ----
@@ -138,42 +175,26 @@ include::example$transactions-example.php[tag=queryExamplesSelect,indent=0]
 // include::example$transactions-example.php[tag=queryExamplesUpdate,indent=0]
 // ----
 
-Here is an example combining SELECTs and UPDATEs.
-It's possible to call regular PHP functions from the lambda, as shown here, permitting complex logic to be performed.
-Just remember that since the lambda may be called multiple times, so may the method.
+And an example combining `SELECT` and an `UPDATE`.
 
 [source,php]
 ----
 include::example$transactions-example.php[tag=queryExamplesComplex,indent=0]
 ----
 
-=== Read Your Own Writes
+As you can see from the snippet above, it is possible to call regular PHP functions from the {lambda}, permitting complex logic to be performed.
+Just remember that since the {lambda} may be called multiple times, so may the method.
 
-As with Key-Value operations, N1QL queries support Read Your Own Writes.
-
-This example shows inserting a document and then selecting it again.
+Like key-value operations, queries support "Read Your Own Writes".
+This example shows inserting a document and then selecting it again:
 
 [source,php]
 ----
 include::example$transactions-example.php[tag=queryRYOW,indent=0]
 ----
-<1> The inserted document is only staged at this point, as the transaction has not yet committed.
+<1> The inserted document is only staged at this point, as the transaction has not yet committed. +
 Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
-<2> But the SELECT can, as we are reading a mutation staged inside the same transaction.
-
-=== Mixing Key-Value and N1QL
-
-Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
-
-In this example we insert a document with Key-Value, and read it with a SELECT.
-
-[source,php]
-----
-include::example$transactions-example.php[tag=queryKvMix,indent=0]
-----
-
-<1> As with the 'Read Your Own Writes' example, here the insert is only staged, and so it is not visible to other transactions or non-transactional actors.
-<2> But the SELECT can view it, as the insert is in the same transaction.
+<2> But the `SELECT` can, as we are reading a mutation staged inside the same transaction.
 
 === Query Options
 
@@ -184,276 +205,52 @@ Query options can be provided via `TransactionQueryOptions`, which provides a su
 include::example$transactions-example.php[tag=queryOptions,indent=0]
 ----
 
-Some of the supported options are:
-
-* adHoc 
-* clientContextId
-* pipelineBatch
-* pipelineCap
-* profile
-* raw
-* readonly
-* scanCap
-* scanConsistency
-* scanWaitMilliseconds
-
-See the https://docs.couchbase.com/sdk-api/couchbase-php-client/classes/Couchbase-TransactionQueryOptions.html[TransactionQueryOptions API] for full details on the supported parameters.
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-perf]
-
-// TODO: Unclear if this feature is available for PHP SDK.
-// include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-single]
-
-// TODO: Ensure the example shows a single query transaction, current one seems incorrect?
-// [source,php]
-// ----
-// include::example$transactions-example.php[tag=querySingle,indent=0]
-// ----
-
-// TODO: As above, check PHP relevance of following.
-// You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
-//
-// [source,typescript]
-// ----
-// include::example$transactions-example.ts[tag=querySingleScoped,indent=0]
-// ----
-//
-// and configure it:
-//
-// [source,typescript]
-// ----
-// include::example$transactions-example.ts[tag=querySingleConfigured,indent=0]
-// ----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=n1ql-rbac]
-
-== Committing
-
-Committing is automatic: 
-If no exception is thrown, the transaction will be committed at the end of the code block with the transaction context.
-If you want to rollback the transaction, simply throw an exception.
-Transactions may rollback from the transaction logic itself, various failure conditions, or from your application logic by throwing an exception.
-
-As soon as the transaction is committed, all its changes will be atomically visible to reads from other transactions.
-The changes will also be committed (or "unstaged") so they are visible to non-transactional actors, in an eventually consistent fashion.
-
-Commit is final: after the transaction is committed, it cannot be rolled back, and no further operations are allowed on it.
-
-An asynchronous cleanup process ensures that once the transaction reaches the commit point, it will be fully committed - even if the application crashes.
-
-
-// == A Full Transaction Example
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=example]
-
-[source,php]
-----
-include::example$transactions-example.php[tag=full,indent=0]
-----
-
-// concurrency
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
-
-// TODO: this is to identify violations of cooperative, not known if this is available in node/cb++
-// [source,java]
-// ----
-// include::example$TransactionsExample.java[tag=concurrency,indent=0]
-// ----
-//
-// These events will be raised in the event of a non-transactional write being detected and overridden.
-// The event contains the key of the document involved, to aid the application with debugging.
-
-
-== Rollback
-
-If an exception is thrown by the application from the lambda, then that attempt is rolled back.
-The transaction logic may or may not be retried, depending on the exception.
-
-// TODO check PHP relevance of following
-// If the transaction is not retried then it will throw an exception, and its `error` contains details on the failure.
-// In Typescript, you may branch your error handling based on `instanceof` with one of `TransactionOperationFailedError`, `TransactionFailedError`, `TransactionExpiredError` or `TransactionCommitAmbiguousError`.
-
-The application can use this to signal why it triggered a rollback, as so:
-
-[source,php]
-----
-include::example$transactions-example.php[tag=rollback-cause,indent=0]
-----
-
-After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the system will not try to automatically commit it at the end of the code block.
-
-
-//  Error Handling
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
-
-These are some of the exceptions that Couchbase transactions can raise to the application: `TransactionFailedException`, `TransactionExpiredException` and `TransactionCommitAmbiguousException`.
-
-// txnfailed
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
-
-// TODO: Need an equivalent PHP snippet for the below
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=config-expiration,indent=0]
-//----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
-
-// TODO: Double check if this will be added in future.
-// Doesn't seem to be available for the PHP SDK.
-//Similar to `TransactionResult`, `SingleQueryTransactionResult` also has an `unstagingComplete()` method.
-
-=== Full Error Handling Example
-
-Pulling all of the above together, this is the suggested best practice for error handling:
-
-[source,php]
-----
-include::example$transactions-example.php[tag=full-error-handling,indent=0]
-----
-
-// Asynchronous Cleanup
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!library-cleanup-buckets]
-
-[#tuning-cleanup]
-=== Configuring Cleanup
-
-The cleanup settings can be configured as so:
-
-[options="header"]
+.Supported Transaction Query Options
 |===
-|Setting|Default|Description
-|`cleanupWindow()`|60 seconds|This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents.  It is perfectly valid for the application to change this setting, which is at a conservative default.  Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
-|`disableLostAttemptCleanup()`|true|This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client.  It is strongly recommended that it is left enabled.
-|`disableClientAttemptCleanup()`|true|This thread is for cleaning up transactions created just by this client.  The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash).  It is strongly recommended that it is left enabled.
+| Name | Description
+
+| `positionalParameters(array<string\|int, mixed>)` | Allows to set positional arguments for a parameterized query.
+| `namedParameters(array<string\|int, mixed>)` | Allows you to set named arguments for a parameterized query.
+| `scanConsistency(string)` | Sets a different scan consistency for this query.
+| `clientContextId(string)` | Sets a context ID returned by the service for debugging purposes.
+| `scanWaitMilliseconds(int)` | Allows to specify a maximum scan wait time.
+| `scanCap(int)` | Specifies a maximum cap on the query scan size.
+| `pipelineBatch(int)` | Sets the batch size for the query pipeline.
+| `pipelineCap(int)` | Sets the cap for the query pipeline.
+| `profile(int)` | Allows you to enable additional query profiling as part of the response.
+| `readonly(bool)` | Tells the client and server that this query is readonly.
+| `adHoc(bool)` | If set to false will prepare the query and later execute the prepared statement.
+| `raw(string)` | Escape hatch to add arguments that are not covered by these options.
 |===
 
-=== Monitoring Cleanup
+== Mixing Key-Value and {sqlpp}
 
-To monitor cleanup, increase the verbosity on the logging.
+Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
 
-//TODO: once events are available, re-add the below
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=cleanup-events,indent=0]
-//----
-//
-//`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
-//(A run is typically around every 60 seconds, with default configuration.)
-//
-//A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
-//It contains whether that attempt was successful, along with any logs relevant to the attempt.
-//
-//In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
-//With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
-//If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
+In this example we insert a document with a key-value operation, and read it with a `SELECT` query.
 
-== Logging
+[source,php]
+----
+include::example$transactions-example.php[tag=queryKvMix,indent=0]
+----
 
-To aid troubleshooting, raise the log level on the SDK.
-// TODO: need to add logging details to the error objects
-//To aid troubleshooting, each transaction maintains a list of log entries, which can be logged on failure like this:
+<1> The key-value insert operation is only staged, and so it is not visible to other transactions or non-transactional actors.
+<2> But the `SELECT` can view it, as the insert was in the same transaction.
 
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=logging,indent=0]
-//----
-//
-//A failed transaction can involve dozens, even hundreds, of lines of logging, so the application may prefer to write failed transactions into a separate file.
-//
-//For convenience there is also a config option that will automatically write this programmatic log to the standard Couchbase Java logging configuration inherited from the SDK if a transaction fails.
-//This will log all lines of any failed transactions, to `WARN` level:
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=config_warn,indent=0]
-//----
-//
+== Configuration
 
-Please see the xref:howtos:collecting-information-and-logging.adoc[PHP SDK logging documentation] for details.
+Transactions can optionally be globally configured when configuring the `Cluster`.
+For example, if you want to change the level of durability which must be attained, this can be configured as part of the connect options:
 
-// TODO: re-add this once tracing becomes available
-//== Tracing
-//
-//This telemetry is particularly useful for monitoring performance.
-//
-//If the underlying Couchbase Java SDK is configured for tracing, then no further work is required: transaction spans will be output automatically.
-//See the xref:howtos:observability-tracing.adoc[Couchbase Java SDK Request Tracing documentation] for how to configure this.
-//
-//=== Parent Spans
-//
-//While the above is sufficient to use and output transaction spans, the application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
-//It can do this by passing that as a parent span.
-//
-//If you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the transactions library:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=tracing-wrapped,indent=0]
-//----
+[source,php]
+----
+include::example$transactions-example.php[tag=config,indent=0]
+----
 
-== Concurrent Operations
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
 
-The API allows operations to be performed concurrently inside a transaction, which can assist performance.
-There are two rules the application needs to follow:
+== Additional Resources
 
-* The first mutation must be performed alone, in serial.
-This is because the first mutation also triggers the creation of metadata for the transaction.
-* All concurrent operations must be allowed to complete fully, so the transaction library can track which operations need to be rolled back in the event of failure.
-This means the application must 'swallow' the error, but record that an error occurred, and then at the end of the concurrent operations, if an error occurred, throw an error to cause the transaction to retry.
+* Learn more about xref:concept-docs:transactions.adoc[Distributed ACID Transactions].
 
-// TODO: update this for PHP
-//These rules are demonstrated here:
-
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=concurrentOps,indent=0]
-//----
-
-
-// TODO: re-enable once custom metadata collections are supported
-// include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
-
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=custom-metadata,indent=0]
-//----
-
-//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-2]
-
-// TODO: re-enable when deferred commits are supported
-//== Deferred Commits
-//
-//NOTE: The deferred commit feature is currently in alpha, and the API may change.
-//
-//Deferred commits allow a transaction to be paused just before the commit point.
-//Optionally, everything required to finish the transaction can then be bundled up into a context that may be serialized into a String or byte array, and deserialized elsewhere (for example, in another process).
-//The transaction can then be committed, or rolled back.
-//
-//The intention behind this feature is to allow multiple transactions, potentially spanning multiple databases, to be brought to just before the commit point, and then all committed together.
-//
-//Here's an example of deferring the initial commit and serializing the transaction:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=defer1,indent=0]
-//----
-//
-//And then committing the transaction later:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=defer2,indent=0]
-//----
-//
-//Alternatively the transaction can be rolled back:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=defer3,indent=0]
-//----
-//
-//The transaction expiry timer (which is configurable) will begin ticking once the transaction starts, and is not paused while the transaction is in a deferred state.
-
-
-// TODO: this partial points to the java examples repo
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=further]
-
+* Check out the SDK https://docs.couchbase.com/sdk-api/couchbase-php-client/namespaces/couchbase.html[API Reference].

--- a/modules/howtos/pages/transactions-single-query.adoc
+++ b/modules/howtos/pages/transactions-single-query.adoc
@@ -1,0 +1,34 @@
+//// TODO: Add when available for Python SDK
+//= Single Query Transactions
+//:description: Learn how to perform bulk-loading transactions with the Python SDKd.
+//:page-partial:
+//:page-topic-type: howto
+//:page-pagination: full
+//
+//include::project-docs:partial$attributes.adoc[]
+//
+//[abstract]
+//{description}
+//
+//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=single-query-transactions-intro]
+//
+//// TODO: Ensure the example shows a single query transaction, current one seems incorrect?
+//[source,php]
+//----
+//include::example$transactions-example.php[tag=querySingle,indent=0]
+//----
+//
+//// TODO: As above, check PHP relevance of following.
+//You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
+//
+//[source,php]
+//----
+//include::example$transactions-example.php[tag=querySingleScoped,indent=0]
+//----
+//
+//and configure it:
+//
+//[source,typescript]
+//----
+//include::example$transactions-example.php[tag=querySingleConfigured,indent=0]
+//----

--- a/modules/howtos/pages/transactions-tracing.adoc
+++ b/modules/howtos/pages/transactions-tracing.adoc
@@ -1,0 +1,26 @@
+//// TODO: Add when available for PHP SDK
+//= Tracing
+//:description: Tracing Couchbase Distributed ACID transactions.
+//:page-partial:
+//:page-topic-type: howto
+//:page-pagination: full
+//
+//[abstract]
+//{description}
+//
+//If configured, detailed telemetry on each transaction can be output that is compatible with various external systems including OpenTelemetry and its predecessor OpenTracing.
+//This telemetry is particularly useful for monitoring performance.
+//
+//See the xref:howtos:observability-tracing.adoc[SDK Request Tracing documentation] for how to configure this.
+//
+//=== Parent Spans
+//
+//While the above is sufficient to use and output transaction spans, the application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
+//It can do this by passing that as a parent span.
+//
+//If you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the transactions library:
+//
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=tracing-wrapped,indent=0]
+//----

--- a/modules/howtos/partials/acid-transactions-attributes.adoc
+++ b/modules/howtos/partials/acid-transactions-attributes.adoc
@@ -21,3 +21,7 @@
 :transaction-config: TransactionsConfiguration
 :transaction-commit-ambiguous: TransactionCommitAmbiguousException
 :txnfailed-unstaging-complete: TransactionResult.unstagingComplete
+
+// lambda
+:lambda: lambda
+:intro-lambda: pass:q[a `lambda`]


### PR DESCRIPTION
Page previews (including sdk-common changes, so it's easier to see it all together):

[Transactions howto guide](https://maria-robobug.github.io/transactions-reorg/php-sdk/4.0/howtos/distributed-acid-transactions-from-the-sdk.html)

[Transactions concept guide](https://maria-robobug.github.io/transactions-reorg/php-sdk/4.0/concept-docs/transactions.html)

NUX improvements:

* Splits howto and concept content as well as removing repetitive sections.

* Adds Capella in Prerequisites.

* Removes repetitive examples from asciidoc where possible.

* Moves Transactions to top level nav, include concept and howto in same
  section.