### PR TITLE
Fix connection string trust certificate

### DIFF
--- a/modules/howtos/examples/managing-connections.php
+++ b/modules/howtos/examples/managing-connections.php
@@ -23,7 +23,7 @@ $cluster = new Cluster($connectionString, $opts);
 $opts = new ClusterOptions();
 $opts->credentials("Administrator", "password");
 
-$connectionString = "couchbases://localhost?truststorepath=/path/to/ca/certificates.pem";
+$connectionString = "couchbases://localhost?trust_certificate=/path/to/ca/certificates.pem";
 $cluster = new Cluster($connectionString, $opts);
 // end::tls[]
 


### PR DESCRIPTION
Fixed example connection string to use ?trust_certificate=