### PR TITLE
DOC-10543 Root CA OpenSSL configuration details

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -95,7 +95,7 @@ TIP: In a deployment that uses multi-dimensional scaling, a custom KV port is on
 A custom manager port may be specified regardless of which services are running on the node.
 
 In many cases the client is able to automatically select the correct set of addresses to use when connecting to a cluster that advertises multiple addresses.
-If the detection heuristic fails in your environment, you can override it by setting the `io.networkResolution` client setting to `default` if the client and server are on the same network, or `external` if they're on different networks
+If the detection heuristic fails in your environment, you can override it by setting the `io.networkResolution` client setting to `default` if the client and server are on the same network, or `external` if they're on different networks.
 
 NOTE: Any TLS certificates must be set up at the point where the connections are being made.
 // todo what does that mean in practice? Also, should this be in the TLS docs section instead?

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -95,7 +95,7 @@ TIP: In a deployment that uses multi-dimensional scaling, a custom KV port is on
 A custom manager port may be specified regardless of which services are running on the node.
 
 In many cases the client is able to automatically select the correct set of addresses to use when connecting to a cluster that advertises multiple addresses.
-If the detection heuristic fails in your environment, you can override it by setting the `io.networkResolution` client setting to `default` if the client and server are on the same network, or `external` if they're on different networks.
+If the detection heuristic fails in your environment, you can override it by setting the `io.networkResolution` client setting to `default` if the client and server are on the same network, or `external` if they're on different networks
 
 NOTE: Any TLS certificates must be set up at the point where the connections are being made.
 // todo what does that mean in practice? Also, should this be in the TLS docs section instead?
@@ -125,11 +125,17 @@ Couchbase Server::
 --
 As of SDK 4.1, if you connect to a Couchbase Server cluster with a root certificate issued by a trusted CA (Certificate Authority), you no longer need to configure the `trust_certificate` path in your connection string.
 
-The cluster's root certificate just needs to be issued by a CA whose certificate is in your system trust store.
+The cluster's root certificate just needs to be issued by a CA whose certificate is in your OpenSSL trust store.
 This includes publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
 The PHP SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the platform root CA.
 
 IMPORTANT: {cbpp} loads your platform's root CA store using OpenSSL, therefore you should make sure that your system or platform is configured to support this.
+
+Some OpenSSL installations are not bundled with any root certificates in its trust store by default, which you may wish to populate.
+
+You can find the OpenSSL version and directory which your php installation uses by running `php -i` in a CLI, and navigating to the openssl section.
+
+You should ensure that within this OpenSSL directory, there exists a `cert.pem` file with the relevant root certificates and/or a `certs` directory populated with these root certificates individually.
 
 You can still provide a certificate explicitly if necessary:
 


### PR DESCRIPTION
- Replaced "system" with "OpenSSL" to be more accurate
- Added details on ensuring that OpenSSL is configured correctly to work with the root CA feature