### PR TITLE
fix(DocumentNotFoundException): use the right namespace

### DIFF
--- a/modules/howtos/examples/errors.php
+++ b/modules/howtos/examples/errors.php
@@ -13,7 +13,7 @@ $collection = $cluster->bucket("travel-sample")->scope("inventory")->collection(
 // tag::document-not-found-exception[]
 try {
     $collection->get("foo");
-} catch (\Couchbase\DocumentNotFoundException $ex) {
+} catch (\Couchbase\Exception\DocumentNotFoundException $ex) {
     printf("Document does not exist, creating. \n");
     $collection->upsert("foo", ["bar" => 42]);
 }
@@ -70,7 +70,7 @@ for ($attempt = 1; $attempt <= $max_attempts; $attempt++) {
         $result = $collection->get("expected-document");
         break;
     }
-    catch (\Couchbase\DocumentNotFoundException $ex) {
+    catch (\Couchbase\Exception\DocumentNotFoundException $ex) {
         printf("Document still not created. \n");
         usleep(100);
         continue;

--- a/modules/howtos/examples/kv-expiry.php
+++ b/modules/howtos/examples/kv-expiry.php
@@ -48,7 +48,7 @@ sleep(2); // wait until the document will expire
 
 try {
     $collection->get($key);
-} catch (Couchbase\DocumentNotFoundException $ex) {
+} catch (Couchbase\Exception\DocumentNotFoundException $ex) {
     printf("The document does not exist\n");
 }
 // end::getandtouch[]


### PR DESCRIPTION
A quick fix: It miss `\Exception\` in the namespase path for the `DocumentNotFoundException`.

Thanks in advance.