### PR TITLE
fix(CasMismatchException): path of namespace

### DIFF
--- a/modules/howtos/examples/errors.php
+++ b/modules/howtos/examples/errors.php
@@ -56,7 +56,7 @@ try {
                          ["bar" => 45],
                          $opts->cas($original_cas));
                          # oops, we should have used $updated_cas!
-} catch (\Couchbase\CasMismatchException $ex) {
+} catch (\Couchbase\Exception\CasMismatchException $ex) {
     printf("CAS mismatch error. \n");
 }
 // end::cas-mismatch-exception[]

--- a/modules/howtos/examples/kv-crud.php
+++ b/modules/howtos/examples/kv-crud.php
@@ -38,7 +38,7 @@ $invalidCas = "776t3gAAAAA=";
 $opts->cas($invalidCas);
 try {
     $collection->replace("document-key", $document, $opts);
-} catch (\Couchbase\CasMismatchException $ex) {
+} catch (\Couchbase\Exception\CasMismatchException $ex) {
     printf("document \"document-key\" cannot be replaced with CAS \"%s\"\n", $invalidCas);
 }
 


### PR DESCRIPTION
I've done a first pr, that had been merged, here: https://github.com/couchbase/docs-sdk-php/pull/120 (thanks to @RichardSmedley )

There is an opened ticket here: https://issues.couchbase.com/browse/DOC-11307

I've fixed some other namespaces I was able to check in the [couchbase-php-client](https://github.com/couchbase/couchbase-php-client) repo.

There's still some exceptions I couldn't find in the SDK code (i.e: `\Couchbase\NetworkException` or `\Couchbase\ValueTooBigException`) so I didn't update the doc for those.

Thanks in advance.