### PR TITLE
Added the preview/HEAD.yml file and the Tip for FTS Limits Cap

### DIFF
--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -64,6 +64,18 @@ A conjunction query contains multiple child queries; its result documents must s
 include::example$search.php[tag=conjunctionquery]
 ----
 
+[TIP]
+.Search Results Limit
+====
+By default, the Search Service returns only the first 10 matches (`size: 10`, `from: 0`).
+To retrieve more results, you must explicitly define pagination settings such as `size` or `from` in your query.
+
+For information about formatting your Search query and specifying limits, see xref:server:search:search-request-params.adoc[].
+
+For information about pagination in Search responses, see xref:server:fts:fts-search-response.adoc#pagination[Pagination].
+====
+
+
 == Working with Results
 
 The result of a search query has three components: rows, facets, and metdata.  Rows are the documents that match the

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: release/8.0
+  docs-devex:
+    branches: release/8.0


### PR DESCRIPTION
[DOC-14072](https://jira.issues.couchbase.com/browse/DOC-14072)

Added a TIP about the FTS search results limit. Added a couple of hyperlinks pointing to docs that reside in the docs-server and docs-devex repos.
Also added the directory and yml file, preview/HEAD.yml, since the docs-sdk-php repo did not have them.

[Doc Preview](https://preview.docs-test.couchbase.com/docs-sdk-php-DOC-14072_PHP_FTS_Limits_Cap/php-sdk/current/howtos/full-text-searching-with-sdk.html)

[DOC-14072]: https://couchbasecloud.atlassian.net/browse/DOC-14072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ